### PR TITLE
[OnConnect] Fix webhook issue when using multiple bots.

### DIFF
--- a/onconnect/commands.py
+++ b/onconnect/commands.py
@@ -115,12 +115,12 @@ class Commands(MixinMeta):
             await ctx.send(embed=em)
             log.info(e)
 
-    @_connectset.command(name="version")
+    @_connectset.command(name="version", hidden=True)
     async def connectset_version(self, ctx: commands.Context):
         """Shows the cog version."""
         em = discord.Embed(
             title="Cog Version:",
             description=f"Author: {self.__author__}\nVersion: {self.__version__}",
-            colour=await ctx.embed_color(),
+            colour=await ctx.embed_colour(),
         )
         await ctx.send(embed=em)

--- a/onconnect/info.json
+++ b/onconnect/info.json
@@ -1,7 +1,7 @@
 {
     "author": ["max"],
     "name": "OnConnect",
-    "install_msg" : "Thanks for installing. Use `[p]connectset` to set event channel.",
+    "install_msg" : "Thanks for installing. Use `[p]connectset channel` to set event channel.",
     "description": "On connect is a shard event cog that shows on ready, disconnect and resummed.",
     "short": "This cog is used to send shard events.",
     "hidden" : false,

--- a/onconnect/onconnect.py
+++ b/onconnect/onconnect.py
@@ -9,6 +9,7 @@ from redbot.core.bot import Red
 from redbot.core.utils import chat_formatting as chat
 
 from .commands import Commands
+from .log import log
 
 
 class CompositeMetaClass(type(commands.Cog), type(ABC)):
@@ -21,7 +22,7 @@ class CompositeMetaClass(type(commands.Cog), type(ABC)):
 class OnConnect(Commands, commands.Cog, metaclass=CompositeMetaClass):
     """This cog is used to send shard events."""
 
-    __version__ = "0.0.5"
+    __version__ = "0.0.6"
     __author__ = "MAX"
 
     def __init__(self, bot: Red) -> None:
@@ -81,8 +82,14 @@ class OnConnect(Commands, commands.Cog, metaclass=CompositeMetaClass):
         if channel_config is None:
             return
 
+        try:
+            channel = await self.get_or_fetch_channel(channel_id=channel_config)
+        except discord.NotFound as e:
+            log.error(f"Statuschannel not found, deleting ID from config. {e}")
+            await self.config.statuschannel.clear()
+            return
+
         event_embed = discord.Embed(description=message, colour=colour)
-        channel = await self.get_or_fetch_channel(channel_id=channel_config)
         webhooks = await channel.webhooks()
         if not webhooks:
             webhook = await channel.create_webhook(name="OnConnect")

--- a/onconnect/onconnect.py
+++ b/onconnect/onconnect.py
@@ -84,9 +84,16 @@ class OnConnect(Commands, commands.Cog, metaclass=CompositeMetaClass):
         event_embed = discord.Embed(description=message, colour=colour)
         channel = await self.get_or_fetch_channel(channel_id=channel_config)
         webhooks = await channel.webhooks()
-        webhook = discord.utils.get(webhooks, name=f"{self.bot.user.name}")
-        if webhook is None:
-            webhook = await channel.create_webhook(name=f"{self.bot.user.name}")
+        if not webhooks:
+            webhook = await channel.create_webhook(name="OnConnect")
+        else:
+            usable_webhooks = [
+                w for w in webhooks if w.token
+            ]  # Based on https://github.com/TheDiscordHistorian/historian-cogs/blob/main/on_connect/cog.py#L45
+            if not usable_webhooks:
+                webhook = await channel.create_webhook(name="OnConnect")
+            else:
+                webhook = usable_webhooks[0]
 
         await webhook.send(
             username=self.bot.user.name,

--- a/onconnect/onconnect.py
+++ b/onconnect/onconnect.py
@@ -85,8 +85,10 @@ class OnConnect(Commands, commands.Cog, metaclass=CompositeMetaClass):
         try:
             channel = await self.get_or_fetch_channel(channel_id=channel_config)
         except discord.NotFound as e:
-            log.error(f"Statuschannel not found, deleting ID from config. {e}")
-            await self.config.statuschannel.clear()
+            if await self.config.statuschannel() is not None:
+                log.error(f"Statuschannel not found, deleting ID from config. {e}")
+                await self.config.statuschannel.clear()
+
             return
 
         event_embed = discord.Embed(description=message, colour=colour)


### PR DESCRIPTION
### Description of the changes

This PR fixes an issue when the bot couldn't send the event webhook because another bot uses a webhook with the same name.