### PR TITLE
[NekosBest] return None on failed API call, guard empty results.

### DIFF
--- a/nekosbest/nekosbest.py
+++ b/nekosbest/nekosbest.py
@@ -75,9 +75,10 @@ class NekosBest(commands.Cog):
                     "Something went wrong while trying to contact API. Status code: %s",
                     response.status,
                 )
-                return await ctx.send(
+                await ctx.send(
                     "Something went wrong while trying to contact API. Please try again later.",
                 )
+                return None
             data = await response.read()
             return orjson.loads(data)
 
@@ -85,7 +86,11 @@ class NekosBest(commands.Cog):
         self, ctx: commands.Context, response: dict[str, Any], category: str
     ) -> None:
         await ctx.typing()
-        data = response["results"][0]
+        results = response.get("results")
+        if not results:
+            await ctx.send("The API returned no data. Try again in a moment.")
+            return
+        data = results[0]
         artist = data["artist_name"]
         source = data["source_url"]
         artist_link = data["artist_href"]
@@ -121,6 +126,10 @@ class NekosBest(commands.Cog):
         url = await self._api_call(ctx, action)
         if url is None:
             return
+        results = url.get("results")
+        if not results:
+            await ctx.send("The API returned no data. Try again in a moment.")
+            return
         await ctx.typing()
         user_config = self.config.user(ctx.author)
         command_counts = await user_config.command_counts()
@@ -139,8 +148,8 @@ class NekosBest(commands.Cog):
         grammar = "times" if count > 1 else "time"
         received_grammar = "times" if received_count > 1 else "time"
         action_fmt = ACTIONS.get(action, action)
-        anime_name = url["results"][0]["anime_name"]
-        image_url = url["results"][0]["url"]
+        anime_name = results[0]["anime_name"]
+        image_url = results[0]["url"]
 
         target_str = f"{member.mention}" if member and member != ctx.author else "themselves!"
         description = f"**{ctx.author.mention} {action_fmt} {target_str}**\n"

--- a/themoviedb/tmdb_utils.py
+++ b/themoviedb/tmdb_utils.py
@@ -77,7 +77,10 @@ PREDEFINED_CHANNELS = {
         "name": "KinoCheck - Your Ultimate Movie Destination!.",
     },
     "vertical": {"id": "UCpR3kmSyTYszJHWEcmpcnFQ", "name": "Vertical Official"},
-    "igntrailer": {"id": "UCWJ5MfdQZ6jXbF5gYuSAf5Q", "name": "IGN Movie Trailers"} # almost same as kinocheck but with more unseen trailers.
+    "igntrailer": {
+        "id": "UCWJ5MfdQZ6jXbF5gYuSAf5Q",
+        "name": "IGN Movie Trailers",
+    },  # almost same as kinocheck but with more unseen trailers.
 }
 
 


### PR DESCRIPTION
`_api_call` returned the sent error `Message` instead of `None` on non-200 responses, so `if url is None` never caught it and the code went on to index into the Message, raising `TypeError: 'Message' object is not subscriptable`.

- `_api_call` now sends the error message and returns `None`
- `embedgen`/`imgembedgen` guard against an empty `results` list (e.g. API returns 200 with no data) before indexing `[0]`
- the empty-results check in `embedgen` runs before usage counters are incremented, so failed calls aren't counted as uses